### PR TITLE
fix: renvoatebot issues where pr's aren't always opening

### DIFF
--- a/defaults.json
+++ b/defaults.json
@@ -12,6 +12,10 @@
   "labels": [
     "auto-update"
   ],
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
+  "rebaseWhen": "behind-base-branch",
+  "dependencyDashboardAutoclose": true,
   "recreateWhen": "always",
   "argocd": {
     "fileMatch": [

--- a/defaults.json
+++ b/defaults.json
@@ -14,10 +14,10 @@
   ],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
-   "gitIgnoredAuthors": ["github@glueops.dev"],
+   "gitIgnoredAuthors": ["github@glueops.dev", "vendors@glueops.dev"],
   "rebaseWhen": "behind-base-branch",
   "dependencyDashboardAutoclose": true,
-  "dependencyDashboard": false,
+  "dependencyDashboard": true,
   "recreateWhen": "always",
   "argocd": {
     "fileMatch": [

--- a/defaults.json
+++ b/defaults.json
@@ -14,6 +14,7 @@
   ],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
+   "gitIgnoredAuthors": ["github@glueops.dev"],
   "rebaseWhen": "behind-base-branch",
   "dependencyDashboardAutoclose": true,
   "dependencyDashboard": false,

--- a/defaults.json
+++ b/defaults.json
@@ -16,6 +16,7 @@
   "prHourlyLimit": 0,
   "rebaseWhen": "behind-base-branch",
   "dependencyDashboardAutoclose": true,
+  "dependencyDashboard": false,
   "recreateWhen": "always",
   "argocd": {
     "fileMatch": [


### PR DESCRIPTION
### **User description**
fix: renvoatebot issues where pr's aren't always opening

Aside from this PR there was also an issue with our internal github app installation not having the correct permissions for renovatebot to update github actions within our private repositories. This permissions issue has been fixed already.


___

### **PR Type**
Bug fix, Configuration changes


___

### **Description**
- Fixed issues with RenovateBot PRs not opening consistently.

- Updated `defaults.json` to include new configuration options:
  - Added `prConcurrentLimit` and `prHourlyLimit` set to 0.
  - Included `gitIgnoredAuthors` to ignore specific authors.
  - Enabled `dependencyDashboard` and set `dependencyDashboardAutoclose` to true.
  - Changed `rebaseWhen` to "behind-base-branch".

- Turned off dependency dashboard and adjusted related settings.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>defaults.json</strong><dd><code>Update RenovateBot configuration in `defaults.json`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

defaults.json

<li>Added <code>prConcurrentLimit</code> and <code>prHourlyLimit</code> with a value of 0.<br> <li> Introduced <code>gitIgnoredAuthors</code> to ignore specific authors.<br> <li> Enabled <code>dependencyDashboard</code> and set <code>dependencyDashboardAutoclose</code> to <br>true.<br> <li> Updated <code>rebaseWhen</code> to "behind-base-branch".


</details>


  </td>
  <td><a href="https://github.com/GlueOps/renovatebot-configs/pull/10/files#diff-8f9b1e3db6a25a9b9fa3e764a4c4b175a8c4888a1f48cbd10d1b63dd7e53076f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>