### PR TITLE
fix: renvoatebot issues where pr's aren't always opening

### DIFF
--- a/defaults.json
+++ b/defaults.json
@@ -12,6 +12,12 @@
   "labels": [
     "auto-update"
   ],
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
+   "gitIgnoredAuthors": ["github@glueops.dev", "vendors@glueops.dev"],
+  "rebaseWhen": "behind-base-branch",
+  "dependencyDashboardAutoclose": true,
+  "dependencyDashboard": true,
   "recreateWhen": "always",
   "argocd": {
     "fileMatch": [


### PR DESCRIPTION
### **User description**
fix: renvoatebot issues where pr's aren't always opening

Aside from this PR there was also an issue with our internal github app installation not having the correct permissions for renovatebot to update github actions within our private repositories. This permissions issue has been fixed already.


___

### **PR Type**
Bug fix, Configuration changes


___

### **Description**
- Fixed RenovateBot issues preventing PR creation.

- Added configuration for concurrent and hourly PR limits.

- Introduced ignored authors and dependency dashboard settings.

- Ensured PRs are recreated when behind the base branch.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>defaults.json</strong><dd><code>Update RenovateBot configuration to fix PR issues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

defaults.json

<li>Added <code>prConcurrentLimit</code> and <code>prHourlyLimit</code> settings.<br> <li> Configured <code>gitIgnoredAuthors</code> to exclude specific authors.<br> <li> Enabled <code>dependencyDashboard</code> and <code>dependencyDashboardAutoclose</code>.<br> <li> Set <code>rebaseWhen</code> to handle branches behind the base branch.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/renovatebot-configs/pull/11/files#diff-8f9b1e3db6a25a9b9fa3e764a4c4b175a8c4888a1f48cbd10d1b63dd7e53076f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>