### PR TITLE
remove defaultRegistry and replace it inside packageRules

### DIFF
--- a/defaults.json
+++ b/defaults.json
@@ -6,11 +6,6 @@
     "helpers:pinGitHubActionDigests",
     ":pinDevDependencies"
   ],
-  "defaultRegistryUrls": [
-    "https://docker.io",
-    "https://ghcr.io/glueops/mirror",
-    "https://quay.io/glueops/mirror"
-  ],
   "separateMinorPatch": true,
   "separateMultipleMajor": true,
   "separateMultipleMinor": true,
@@ -361,6 +356,17 @@
       ],
       "packageNames": [
         "argo-cd"
+      ]
+    },
+    {
+      "registryUrls": [
+        "https://ghcr.io/glueops/mirror"
+      ],
+      "matchRepositories": [
+        "GlueOps/platform-helm-chart-platform"
+      ],
+      "matchFileNames": [
+        "values.yaml"
       ]
     }
   ]


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Removed `defaultRegistryUrls` from the global configuration.

- Added specific `registryUrls` for `GlueOps/platform-helm-chart-platform`.

- Updated `packageRules` to include `matchRepositories` and `matchFileNames`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>defaults.json</strong><dd><code>Refined registry configuration and package rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

defaults.json

<li>Removed <code>defaultRegistryUrls</code> from global configuration.<br> <li> Added <code>registryUrls</code> for <code>GlueOps/platform-helm-chart-platform</code>.<br> <li> Introduced <code>matchRepositories</code> and <code>matchFileNames</code> for targeted rules.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/renovatebot-configs/pull/14/files#diff-8f9b1e3db6a25a9b9fa3e764a4c4b175a8c4888a1f48cbd10d1b63dd7e53076f">+11/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>